### PR TITLE
fix: increase gap between playback timestamps to prevent overlap

### DIFF
--- a/ziro.css
+++ b/ziro.css
@@ -115,10 +115,10 @@
   color: var(--spice-subtext);
   position: absolute;
   margin-bottom: 30px;
-  right: 266px;
+  right: 280px;
 }
 .playback-bar__progress-time-elapsed {
-  right: 308px;
+  right: 330px;
 }
 .playback-bar__progress-time-elapsed::after {
   content: '  /';


### PR DESCRIPTION
Closes #19
The elapsed and remaining time stamps overlap when the elapsed time reaches M:SS format. The gap between the two right values was not large enough to accommodate both timestamps simultaneously.
Before:
<img width="394" height="83" alt="image" src="https://github.com/user-attachments/assets/cb3bad6e-ceba-4f6a-8fb7-d190b5ed109e" />

After:
<img width="405" height="86" alt="image" src="https://github.com/user-attachments/assets/e5b2b847-85ab-414f-aecd-12239c7a25d7" />
